### PR TITLE
Increase line height to improve accessibility

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -54,7 +54,7 @@ body {
     font-family: 'PT Sans';
     display: flex;
     flex-direction: column;
-    line-height: 1.3;
+    line-height: 1.5;
     font-size: 18pt;
     min-width: 500px;
 }


### PR DESCRIPTION
While reading the website, I find the short line height relatively hard to read. Bumping it to 1.5 helped a lot, and is also [an accessibility recommendation of WCAG](https://w3c.github.io/wcag/guidelines/22/#visual-presentation) (MDN is a bit more direct in [its advice](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#accessibility)).

|Before|After|
|---|---|
|<img width="2828" height="4458" alt="image" src="https://github.com/user-attachments/assets/1c648d8d-83a8-4165-88eb-c8969d49cbfb" />|<img width="2828" height="4866" alt="image" src="https://github.com/user-attachments/assets/07c7d758-137c-4a70-8cea-9fbbb09ce1a4" />|
|<img width="2828" height="1808" alt="image" src="https://github.com/user-attachments/assets/c19f43d2-0a89-4fbc-8913-b4eaf8c28019" />|<img width="2828" height="1808" alt="image" src="https://github.com/user-attachments/assets/8fbd2c32-ea4e-419b-bf2e-994c13033ec3" />|