### PR TITLE
Don't justify text for accessibility purposes

### DIFF
--- a/haunt.scm
+++ b/haunt.scm
@@ -156,8 +156,7 @@
 
 (define pitch
   `(div
-    (@ (class "pitch")
-       (style "text-align: justify;"))
+    (@ (class "pitch"))
     (p "Don't you miss the days when the web really was the world's greatest "
        "decentralized network?  Before everything got locked down into a handful "
        "of walled gardens?  So do we.")


### PR DESCRIPTION
Similar to https://github.com/swicg/activitypub.rocks/pull/39, this was initially a personal preference, since I find it easier to read text when it's not justified. It's nice to see that I'm not the only one(!), since, per the "Visual Representation" section of the WCAG:

> Text is not justified (aligned to both the left and the right margins).

https://w3c.github.io/wcag/guidelines/22/#visual-presentation