### PR TITLE
PR: separate out old from new news

### DIFF
--- a/haunt.scm
+++ b/haunt.scm
@@ -226,6 +226,16 @@
            ", a W3C Community Group to continue the work of advancing the "
            "federated social web... including ActivityPub!")))
 
+(define (posts-with-tag posts tag)
+  (filter (lambda (p)
+             (member tag (post-tags p)))
+           posts ))
+
+(define (posts-without-tag posts tag)
+  (filter (lambda (p)
+             (not (member tag (post-tags p))))
+           posts ))
+
 (define (news-feed site posts)
   `(div (@ (class "news-feed"))
         (header "-=* ActivityPub News *=-")
@@ -235,7 +245,7 @@
                          ,(post-ref post 'title))
                       (div (@ (class "news-feed-item-date"))
                            ,(date->string* (post-date post)))))
-               (take-up-to 10 (posts/reverse-chronological posts))))))
+               (take-up-to 10 (posts/reverse-chronological (posts-without-tag posts "old")))))))
 
 
 (define (index-content site posts)

--- a/haunt.scm
+++ b/haunt.scm
@@ -85,7 +85,6 @@
              "Haunt")
           "."))))
 
-
 ;;; Blog
 
 (define (post-uri site post)
@@ -245,7 +244,11 @@
                          ,(post-ref post 'title))
                       (div (@ (class "news-feed-item-date"))
                            ,(date->string* (post-date post)))))
-               (take-up-to 10 (posts/reverse-chronological (posts-without-tag posts "old")))))))
+               (take-up-to 10 (posts/reverse-chronological (posts-without-tag posts "old")))))
+        (p (@ (class "older"))
+          (a (@ (href "/historic/news/index.html"))
+              "Older News")
+        )))
 
 
 (define (index-content site posts)
@@ -304,8 +307,28 @@
    (impl-report-page-tmpl site)
    sxml->html))
 
+(define (historic-page-tmpl site posts)
+  (define tmpl
+    `(div
+      (h1 "Historic news")
+      (p "For current news, see the "
+         (a (@ (href "/")) "home page."))
+      (ul
+       ,(map (lambda (post)
+               `(li (a (@ (href ,(post-uri site post)))
+                       ,(post-ref post 'title))
+                    (div (@ (class "news-feed-item-date"))
+                         ,(date->string* (post-date post)))))
+              (posts/reverse-chronological (posts-with-tag posts "old"))))))
+  (base-tmpl site tmpl))
 
-
+
+(define (historic-page site posts)
+  (make-page
+   "historic/news/index.html"
+   (historic-page-tmpl site posts)
+   sxml->html))
+
 ;;; Site
 
 (site #:title "ActivityPub Rocks!"
@@ -318,6 +341,7 @@
                        index-page
                        test-page
                        impl-report-page
+                       historic-page
                        (atom-feed #:blog-prefix "/news")
                        (static-directory "static" "/static")
                        (atom-feeds-by-tag)))

--- a/posts/activitypub-reaches-cr.skr
+++ b/posts/activitypub-reaches-cr.skr
@@ -3,6 +3,7 @@
  :date (make-date* 2016 11 17)
  :slug "activitypub-reaches-cr"
  :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p [We're thrilled to announce that
      ,(anchor [ActivityPub] "https://www.w3.org/TR/activitypub/")

--- a/posts/activitypub-reaches-pr.skr
+++ b/posts/activitypub-reaches-pr.skr
@@ -3,6 +3,7 @@
  :date (make-date* 2017 12 08)
  :slug "activitypub-reaches-pr"
  :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p [A little over one year later after
      ,(anchor [reaching Candidate Recommendation status]

--- a/posts/activitypub-rocks-launches.skr
+++ b/posts/activitypub-rocks-launches.skr
@@ -2,6 +2,7 @@
  :title "activitypub.rocks launches!"
  :date (make-date* 2016 11 14 8 45)
  :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p [Today marks the launch of
      ,(anchor [activitypub.rocks] "https://activitypub.rocks"),

--- a/posts/let-us-meet-on-socialhub.skr
+++ b/posts/let-us-meet-on-socialhub.skr
@@ -3,6 +3,7 @@
  :date (make-date* 2019 12 26 17 46)
  :author "hellekin"
  :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p [In case you missed the latest and hottest in the ActivityPub
      community, for a few months we have revived the

--- a/posts/mastodon-ap-and-new-cr.skr
+++ b/posts/mastodon-ap-and-new-cr.skr
@@ -2,7 +2,8 @@
  :title "Mastodon launches their ActivityPub support, and a new CR!"
  :date (make-date* 2017 09 10)
  :slug "mastodon-ap-and-new-cr"
-  :author "Christine Lemmer-Webber"
+ :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p [Greetings!
      Big news this week, from multiple directions!])

--- a/posts/new-activitypub-tutorial.skr
+++ b/posts/new-activitypub-tutorial.skr
@@ -3,6 +3,7 @@
  :date (make-date* 2017 05 09 15 10)
  :slug "new-tutorial-new-logo"
  :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p [A
      ,(anchor [new Candidate Recommendation]

--- a/posts/overdue-site-updates.skr
+++ b/posts/overdue-site-updates.skr
@@ -3,6 +3,7 @@
  :date (make-date* 2021 01 04)
  :slug "overdue-site-updates"
  :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p [Hello, hello... it's been about a year since
      ,(anchor [SocialHub launched] "../news/let-us-meet-on-socialhub.html").

--- a/posts/submit-implementation-reports.skr
+++ b/posts/submit-implementation-reports.skr
@@ -3,6 +3,7 @@
  :date (make-date* 2017 04 09)
  :slug "submit-implementation-reports"
  :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p (em [This was done a while ago, but I forgot to update the website.
          Oops!]))

--- a/posts/test-suite-running-impl-reports-page-up.skr
+++ b/posts/test-suite-running-impl-reports-page-up.skr
@@ -5,6 +5,7 @@
  :date (make-date* 2017 11 06)
  :slug "test-suite-running-and-impl-reports-page-up"
  :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p [I'm happy to announce that the
      ,(anchor [ActivityPub test suite]

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,16 +1,16 @@
 /* activitypub.rocks website
    Copyright © 2016 Christine Lemmer-Webber <cwebber@dustycloud.org>
-  
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-  
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-  
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -153,6 +153,10 @@ h1, h2, h3, h4 {
 }
 
 
+.news-feed p.older {
+    margin-top: 30pt;
+}
+
 div.blogpost {
     border-radius: 5px;
     border: 3px solid #cacae4;
@@ -247,7 +251,7 @@ table.impl-reports tr.test-item-row {
     border-bottom: 1px solid #c4c4c4;
 }
 
-table.impl-reports td.result-cell:not(:last-child), 
+table.impl-reports td.result-cell:not(:last-child),
 table.impl-reports th.report-name:not(:last-child) {
     border-right: 1px solid #c4c4c4;
 }


### PR DESCRIPTION
Move old news items onto a separate page. Closes #1.