### PR TITLE
Updates per today's TF meeting

### DIFF
--- a/haunt.scm
+++ b/haunt.scm
@@ -217,7 +217,11 @@
                 "How to make friends and verify requests. Implementing an ActivityPub inbox") ": Blog post by Eugen Rochko from the Mastodon project")
             (li (a (@ (href "https://fedidevs.org")) "FediDevs.org") ": Developer documentation and community"))
         (p "Interactive exploration:")
-        (ul (li (a (@ (href "https://activitypub.academy")) "ActivityPub.academy") ": A modified Mastodon instance for interactive protocol exploration"))
+        (ul (li (a (@ (href "https://activitypub.academy")) "ActivityPub.academy") ": A modified Mastodon instance for interactive protocol exploration")
+            (li (a (@ (href "https://httpsig.org")) "httpsig.org") ": Try out HTTP signatures (RFC 9421) interactively"))
+
+
+
         (p "Libraries:")
         (ul (li (a (@ (href "https://fedify.dev")) "Fedify - ActivityPub server framework") ": Typescript library"))
         (p "Testing:")

--- a/posts/activitypub-reaches-w3c-recommendation.skr
+++ b/posts/activitypub-reaches-w3c-recommendation.skr
@@ -3,6 +3,7 @@
  :date (make-date* 2018 03 20)
  :slug "activitypub-reaches-w3c-recommendation"
  :author "Christine Lemmer-Webber"
+ :tags '("old")
 
  (p (em [Ooops... this post was written months ago, but accidentally wasn't
          pushed publicly till now!

--- a/posts/basic-profile-for-social-api-servers.md
+++ b/posts/basic-profile-for-social-api-servers.md
@@ -2,7 +2,7 @@ title: Initial Draft of Basic Profile for ActivityPub API Servers
 author: Evan Prodromou
 date: 2026-05-19 10:00
 desc: New draft document from the ActivityPub API task force
-tags: api
+tags: api, old
 ---
 
 There is a new [Basic Profile for ActivityPub API Servers](https://swicg.github.io/activitypub-api/basicprofile) initial draft put out by the [ActivityPub API Task Force](https://swicg.github.io/activitypub-api/). Developers and community members are encouraged to provide feedback on the [issue tracker for the task force](https://github.com/swicg/activitypub-api/issues).

--- a/posts/groups-initial-draft-adopted.md
+++ b/posts/groups-initial-draft-adopted.md
@@ -2,7 +2,7 @@ title: Groups task force: initial draft adopted for task force report
 author: a
 date: 2026-05-28 17:43
 desc: At today's meeting, we adopted an initial draft of the Groups TF report
-tags: groups, task forces, progress update
+tags: groups, task forces, progress update, old
 ---
 
 Originally posted at: <https://lists.w3.org/Archives/Public/public-swicg/2026May/0043.html>

--- a/posts/handing-off-aprocks-to-community.md
+++ b/posts/handing-off-aprocks-to-community.md
@@ -2,7 +2,7 @@ title: Handing off activitypub.rocks to the ActivityPub community
 author: Christine Lemmer-Webber
 date: 2025-08-28 10:00
 desc: Handing off activitypub.rocks to the ActivityPub community
-tags: meta, website
+tags: meta, website, old
 ---
 Hello everyone, Christine Lemmer-Webber here. I'm here to hand off
 this humble website, built and maintained by myself but, to be honest,
@@ -27,7 +27,7 @@ would not become a W3C standard for another two years.
 It was unclear at the time this website was created that ActivityPub
 would reach the level of success it has. ActivityPub has a long
 history, preceding even its work in the W3C process, with its most
-clear beginnings as the 
+clear beginnings as the
 [Pump.io API](https://github.com/pump-io/pump.io/blob/master/API.md)
 designed by Evan Prodromou.
 Erin Shepherd transformed pump.io's API documentation into a draft of

--- a/posts/lola-0.3-available.md
+++ b/posts/lola-0.3-available.md
@@ -1,7 +1,7 @@
 title: LOLA Portability for ActivityPub 0.3 available
 author: Johannes Ernst
 date: 2026-06-15 14:54
-tags: portability, progress update
+tags: portability, progress update, old
 ---
 
 A [new version of the LOLA Portability for ActivityPub specification](https://swicg.github.io/activitypub-data-portability/lola.html)

--- a/posts/maintaining-activitypub-rocks-going-forward.skr
+++ b/posts/maintaining-activitypub-rocks-going-forward.skr
@@ -3,6 +3,7 @@
  :date (make-date* 2025 09 03)
  :slug "maintaining-activitypub-rocks-going-forward"
  :author "Johannes Ernst"
+ :tags '("old")
 
  (p [Hi all, this is ,(anchor [Johannes Ernst] "https://j12t.org/"), in my role as the lead
     of the website task force of the

--- a/posts/w3c-blog-vs-activitypub-rocks.md
+++ b/posts/w3c-blog-vs-activitypub-rocks.md
@@ -1,0 +1,15 @@
+title: Blog posts with ActivityPub updates have moved to WordPress on the W3C's website
+author: Johannes Ernst
+date: 2026-08-04 14:21
+tags: progress update
+---
+
+At today's meeting of the Website Task Force of the Social Web Incubator Community Group
+in the W3C -- wow, that's a handful! But that's the group that has the responsibility of
+editing this site -- we decided to use the [WordPress blog](https://www.w3.org/community/socialcg)
+that the W3C provides us with for future blog-style updates. And not have some updates here and
+some there, which confuses everbody.
+
+The previous posts on this site are [still here](/historic/news/index.html) but some of
+the important onces have been back-ported over there, such as
+[this one](https://www.w3.org/community/socialcg/2018/03/20/activitypub-reaches-w3c-recommendation-status-everybody-party/).

--- a/upload.sh
+++ b/upload.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-rsync --recursive --verbose site/ dustycloud:/srv/activitypub.rocks/site/


### PR DESCRIPTION
Removed obsolete upload script
Moved all blog posts into old
Added blog post explaining that posts are now on the W3C site
Backported the important old posts to W3C WordPress